### PR TITLE
Fix compiling when using kernel 5.10.52 v7+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ module_upload=${MODULE}.ko
 all:	clean compile dht22-overlay.dtbo
 
 dht22-overlay.dtbo:
-	 dtc -I dts -O dtb -o dht22.dtbo dht22-overlay.dts
+	dtc -I dts -O dtb -o dht22.dtbo dht22-overlay.dts
  
 compile:
 	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
@@ -19,6 +19,17 @@ clean:
 # this just copies a file to raspberry
 #install:
 #	scp ${module_upload} pi@raspberry:test/
+
+# This will only work if compiling on the pi
+install:
+	cp ${MODULE}.ko /lib/modules/$(shell uname -r)/kernel/drivers/iio/humidity/
+	cp ${MODULE}.dtbo /boot/overlays/
+	depmod -a 
+
+uninstall:
+	rm -fv /lib/modules/$(shell uname -r)/kernel/drivers/iio/humidity/${MODULE}.ko
+	rm -fv /boot/overlays/${MODULE}.dtbo
+
  
 info:
 	modinfo  ${module_upload}

--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ Do not forget to make a "depmod -a".
 
 At the moment the driver is in a early beta stage.
 But you should not get read errors.
+
+
+## Install using make
+Clone repo
+cd to repo directory
+run ```make```
+run ```make install``` to place the necessary files in the kernel modules directory and /boot/overlays
+reboot
+
+You can verify that it is working correctly by running this command, which should show similar output
+```
+# cat /sys/devices/platform/dht22\@0/iio\:device0/in_humidityrelative_input 
+59.400000000
+```


### PR DESCRIPTION
This resolves the errors that prevent the module from being built on the raspberry pi on kernel 5.10.52 v7+.  Fixes #1 